### PR TITLE
SLING-12915 Refactor to replace usage of the guava library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,6 @@
             <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>15.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/apache/sling/commons/osgi/BundleFileProcessorTest.java
+++ b/src/test/java/org/apache/sling/commons/osgi/BundleFileProcessorTest.java
@@ -51,9 +51,10 @@ public class BundleFileProcessorTest {
         File tempDir = new File(System.getProperty("java.io.tmpdir"));
 
         // Just take any bundle from the maven deps as an example...
-        File originalFile = getMavenArtifactFile(getMavenRepoRoot(), "com.google.guava", "guava", "15.0");
+        File originalFile =
+                getMavenArtifactFile(getMavenRepoRoot(), "org.apache.sling", "org.apache.sling.api", "2.0.6");
 
-        File generatedFile = new BSNRenamer(originalFile, tempDir, "org.acme.baklava.guava").process();
+        File generatedFile = new BSNRenamer(originalFile, tempDir, "org.acme.baklava.sling.api").process();
 
         try {
             compareJarContents(originalFile, generatedFile);
@@ -78,7 +79,7 @@ public class BundleFileProcessorTest {
                                 orgVal,
                                 newAttrs.getValue("X-Original-Bundle-SymbolicName"));
 
-                        assertEquals("org.acme.baklava.guava", newVal);
+                        assertEquals("org.acme.baklava.sling.api", newVal);
                     } else {
                         assertEquals("Different keys: " + key, orgVal, newVal);
                     }

--- a/src/test/java/org/apache/sling/commons/osgi/RankedServicesTest.java
+++ b/src/test/java/org/apache/sling/commons/osgi/RankedServicesTest.java
@@ -18,10 +18,12 @@
  */
 package org.apache.sling.commons.osgi;
 
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterators;
 import org.apache.sling.commons.osgi.RankedServices.ChangeListener;
 import org.junit.Test;
 import org.osgi.framework.Constants;
@@ -34,20 +36,14 @@ import static org.mockito.Mockito.verify;
 public class RankedServicesTest {
 
     private static final String SERVICE_1 = "service1";
-    private static final Map<String, Object> SERVICE_1_PROPS = ImmutableMap.<String, Object>builder()
-            .put(Constants.SERVICE_RANKING, 50)
-            .put(Constants.SERVICE_ID, 1L)
-            .build();
+    private static final Map<String, Object> SERVICE_1_PROPS =
+            Map.of(Constants.SERVICE_RANKING, 50, Constants.SERVICE_ID, 1L);
     private static final String SERVICE_2 = "service2";
-    private static final Map<String, Object> SERVICE_2_PROPS = ImmutableMap.<String, Object>builder()
-            .put(Constants.SERVICE_RANKING, 10)
-            .put(Constants.SERVICE_ID, 2L)
-            .build();
+    private static final Map<String, Object> SERVICE_2_PROPS =
+            Map.of(Constants.SERVICE_RANKING, 10, Constants.SERVICE_ID, 2L);
     private static final String SERVICE_3 = "service3";
-    private static final Map<String, Object> SERVICE_3_PROPS = ImmutableMap.<String, Object>builder()
-            .put(Constants.SERVICE_RANKING, 100)
-            .put(Constants.SERVICE_ID, 3L)
-            .build();
+    private static final Map<String, Object> SERVICE_3_PROPS =
+            Map.of(Constants.SERVICE_RANKING, 100, Constants.SERVICE_ID, 3L);
 
     @Test
     public void testSortedServicesAscending() {
@@ -56,22 +52,28 @@ public class RankedServicesTest {
 
         underTest.bind(SERVICE_1, SERVICE_1_PROPS);
         assertEquals(1, underTest.get().size());
-        Comparable[] services = Iterators.toArray(underTest.get().iterator(), Comparable.class);
+        Comparable[] services = toArray(underTest.get().iterator(), Comparable.class);
         assertSame(SERVICE_1, services[0]);
 
         underTest.bind(SERVICE_2, SERVICE_2_PROPS);
         underTest.bind(SERVICE_3, SERVICE_3_PROPS);
         assertEquals(3, underTest.get().size());
-        services = Iterators.toArray(underTest.get().iterator(), Comparable.class);
+        services = toArray(underTest.get().iterator(), Comparable.class);
         assertSame(SERVICE_2, services[0]);
         assertSame(SERVICE_1, services[1]);
         assertSame(SERVICE_3, services[2]);
 
         underTest.unbind(SERVICE_2, SERVICE_2_PROPS);
         assertEquals(2, underTest.get().size());
-        services = Iterators.toArray(underTest.get().iterator(), Comparable.class);
+        services = toArray(underTest.get().iterator(), Comparable.class);
         assertSame(SERVICE_1, services[0]);
         assertSame(SERVICE_3, services[1]);
+    }
+
+    private Comparable[] toArray(Iterator<Comparable> iterator, Class<Comparable> class1) {
+        Spliterator<Comparable> spliterator = Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED);
+        return StreamSupport.stream(spliterator, false) // false for sequential stream
+                .toArray(Comparable[]::new);
     }
 
     @Test
@@ -81,20 +83,20 @@ public class RankedServicesTest {
 
         underTest.bind(SERVICE_1, SERVICE_1_PROPS);
         assertEquals(1, underTest.get().size());
-        Comparable[] services = Iterators.toArray(underTest.get().iterator(), Comparable.class);
+        Comparable[] services = toArray(underTest.get().iterator(), Comparable.class);
         assertSame(SERVICE_1, services[0]);
 
         underTest.bind(SERVICE_2, SERVICE_2_PROPS);
         underTest.bind(SERVICE_3, SERVICE_3_PROPS);
         assertEquals(3, underTest.get().size());
-        services = Iterators.toArray(underTest.get().iterator(), Comparable.class);
+        services = toArray(underTest.get().iterator(), Comparable.class);
         assertSame(SERVICE_3, services[0]);
         assertSame(SERVICE_1, services[1]);
         assertSame(SERVICE_2, services[2]);
 
         underTest.unbind(SERVICE_2, SERVICE_2_PROPS);
         assertEquals(2, underTest.get().size());
-        services = Iterators.toArray(underTest.get().iterator(), Comparable.class);
+        services = toArray(underTest.get().iterator(), Comparable.class);
         assertSame(SERVICE_3, services[0]);
         assertSame(SERVICE_1, services[1]);
     }


### PR DESCRIPTION
Refactor to replace usage of the guava library as the usage can be done with the standard java features.

Also, will resolve dependabot reporting the direct dependency as "Known security vulnerabilities detected"