### PR TITLE
SLING-12916 bump org.apache.sling.api test dependency to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
             <!-- Not used by our code, but need a bundle jar for unit tests -->
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.0.6</version>
+            <version>2.25.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/commons/osgi/BundleFileProcessorTest.java
+++ b/src/test/java/org/apache/sling/commons/osgi/BundleFileProcessorTest.java
@@ -52,7 +52,7 @@ public class BundleFileProcessorTest {
 
         // Just take any bundle from the maven deps as an example...
         File originalFile =
-                getMavenArtifactFile(getMavenRepoRoot(), "org.apache.sling", "org.apache.sling.api", "2.0.6");
+                getMavenArtifactFile(getMavenRepoRoot(), "org.apache.sling", "org.apache.sling.api", "2.25.4");
 
         File generatedFile = new BSNRenamer(originalFile, tempDir, "org.acme.baklava.sling.api").process();
 
@@ -110,7 +110,12 @@ public class BundleFileProcessorTest {
                 }
 
                 assertEquals(je1.getName(), je2.getName());
-                assertEquals(je1.getSize(), je2.getSize());
+                long je1size = je1.getSize();
+                long je2size = je2.getSize();
+                // if either return -1 then the size is not known so we can't compare them
+                if (je1size != -1 && je2size != -1) {
+                    assertEquals(je1size, je2size);
+                }
 
                 try {
                     byte[] buf1 = streamToByteArray(jis1);

--- a/src/test/java/org/apache/sling/commons/osgi/bundleversion/FileBundleVersionInfoTest.java
+++ b/src/test/java/org/apache/sling/commons/osgi/bundleversion/FileBundleVersionInfoTest.java
@@ -44,9 +44,10 @@ public class FileBundleVersionInfoTest {
         final File testJar = getTestJar("org.apache.sling.api");
         final BundleVersionInfo<?> vi = new FileBundleVersionInfo(testJar);
         assertEquals("org.apache.sling.api", vi.getBundleSymbolicName());
-        assertEquals(vi.getVersion(), new Version("2.0.6"));
+        assertEquals(vi.getVersion(), new Version("2.25.4"));
         assertFalse(vi.isSnapshot());
-        assertEquals(1250080966786L, vi.getBundleLastModified());
+        // NOTE: the 2.25.4 version doesn't include the Bnd-LastModified header anymore
+        assertEquals(-1L, vi.getBundleLastModified());
         assertTrue(vi.isBundle());
         final Object src = vi.getSource();
         assertTrue(src instanceof File);


### PR DESCRIPTION
bump org.apache.sling.api test dependency to 2.25.4 to resolve dependabot warnings about direct dependency with "Known security vulnerabilities detected"